### PR TITLE
Document configuring the LTI via .env and config/*.yml files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ config/resque.yml
 config/s3.yml
 config/sentry.yml
 config/database.yml
+config/mail.yml

--- a/README.md
+++ b/README.md
@@ -31,7 +31,13 @@ key to Canvas for rollcall to connect with. As an admin account, go to
 ID number (an integer) from the index page along with the token and add
 them as `CANVAS_KEY` and `CANVAS_SECRET`, respectively, in `.env`.
 
-### 2. Docker build + Database migrations:
+### 2. Configure the LTI
+
+The LTI will run in development without further configuration; however, some things like mail delivery (for attendance report exports) may not work. You can further configure the LTI by specifying environment variables in `.env`. Refer to `env.sample` for inspiration.
+
+Some aspects (such as database and mail) can also be configured in the traditional Rails way of YAML files in the `config` directory. Refer to `config/database.yml.sample` and `config/mail.yaml.sample` for examples.
+
+### 3. Docker build + Database migrations:
 
 Now you should be able to build your containers with:
 
@@ -44,7 +50,7 @@ rake tasks, you just have to run them in the container:
     docker-compose run --rm web bundle exec rake db:create
     docker-compose run --rm web bundle exec rake db:migrate
 
-### 3. Run it!
+### 4. Run it!
 
 You should be able to start everything with:
 
@@ -56,7 +62,7 @@ AWS resources. When they're running, you can visit your app in the browser by go
 
 `http://rollcall.docker`
 
-### 8. Add Roll Call to Canvas:
+### 5. Add Roll Call to Canvas:
 
 In Canvas, go to Account >> Settings >> Apps, click "Add App", and use the following settings:
 

--- a/config/mail.yml.sample
+++ b/config/mail.yml.sample
@@ -1,0 +1,22 @@
+---
+defaults: &defaults
+  address: mail.yourdomain.edu
+  port: 465
+  authentication: plain
+  user_name: someuser
+  password: itsasecret
+  domain: yourdomain.edu
+  enable_starttls_auto: true
+  openssl_verify_mode: none
+
+development:
+  <<: *defaults
+
+test: &test
+  <<: *defaults
+
+cucumber:
+  <<: *test
+
+production:
+  <<: *defaults

--- a/env.sample
+++ b/env.sample
@@ -22,3 +22,16 @@ LTI_REQUIRE_CANVAS='true'
 
 # Or configure config/database.yml
 DATABASE_URL='postgres://postgres@db:5432/rollcall_dev'
+
+# If you want to be able to send attendance reports by email,
+# you must configure the following, or configure config/mail.yml. 
+# If not configured, mail will not be sent.
+
+SMTP_ADDRESS=mail.yourdomain.edu
+SMTP_PORT=465
+SMTP_AUTHENTICATION=plain # none, plain, login, or cram_md5
+SMTP_USER_NAME=someuser
+SMTP_PASSWORD=itsasecret
+SMTP_DOMAIN=yourdomain.edu
+SMTP_ENABLE_STARTTLS_AUTO=true # true, false
+SMTP_OPENSSL_VERIFY_MODE=none # none, peer, client_once, fail_if_no_peer_cert


### PR DESCRIPTION
Sending attendance reports won't work unless mail is configured. This documents how to pass configuration via either `.env`, or traditional YAML files in `config/`.

I didn't see any relevant specs to add to.