### PR TITLE
Allow customizing the From: address for attendance reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The LTI will run in development without further configuration; however, some thi
 
 Some aspects (such as database and mail) can also be configured in the traditional Rails way of YAML files in the `config` directory. Refer to `config/database.yml.sample` and `config/mail.yaml.sample` for examples.
 
+Note that in production you will want to make sure to configure the SMTP outgoing address parameter to an email address on your own domain; otherwise, your reports will be sent from "`Roll Call <notifications@instructure.com>`", which is most certainly not what you want.
+
 ### 3. Docker build + Database migrations:
 
 Now you should be able to build your containers with:

--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -20,6 +20,6 @@ class ReportMailer < ActionMailer::Base
     @error_message = error_message
     @url = url
 
-    mail from: "Roll Call <notifications@instructure.com>", to: recipient, subject: "Roll Call Attendance Report"
+    mail to: recipient, subject: "Roll Call Attendance Report"
   end
 end

--- a/config/initializers/mail.rb
+++ b/config/initializers/mail.rb
@@ -49,6 +49,5 @@ if smtp_settings.present?
   ActionMailer::Base.delivery_method = :smtp
 end
 
-if default_options.present?
-    ActionMailer::Base.default_options = { from: default_options[:outgoing_address] || "Roll Call <notifications@instructure.com>" }
-end
+ActionMailer::Base.default_options = { from: default_options[:outgoing_address] || "Roll Call <notifications@instructure.com>" }
+

--- a/config/initializers/mail.rb
+++ b/config/initializers/mail.rb
@@ -28,7 +28,8 @@ else
   smtp_settings[:domain] = ENV['SMTP_DOMAIN']
   smtp_settings[:enable_starttls_auto] = ENV['SMTP_ENABLE_STARTTLS_AUTO']
   smtp_settings[:openssl_verify_mode] = ENV['SMTP_OPENSSL_VERIFY_MODE']
-
+  smtp_settings[:outgoing_address] = ENV['SMTP_OUTGOING_ADDRESS']
+  
   smtp_settings.delete_if { |k,v| v.blank? }
 
   if smtp_settings.present?
@@ -40,4 +41,5 @@ end
 if smtp_settings.present?
   ActionMailer::Base.smtp_settings = smtp_settings
   ActionMailer::Base.delivery_method = :smtp
+  ActionMailer::Base.default_options = { from: smtp_settings[:outgoing_address] || "Roll Call <notifications@instructure.com>" }
 end

--- a/config/initializers/mail.rb
+++ b/config/initializers/mail.rb
@@ -33,7 +33,7 @@ else
   smtp_settings[:enable_starttls_auto] = ENV['SMTP_ENABLE_STARTTLS_AUTO']
   smtp_settings[:openssl_verify_mode] = ENV['SMTP_OPENSSL_VERIFY_MODE']
   
-  default_options[:outgoing_address] = ENV[OUTGOING_ADDRESS]
+  default_options[:outgoing_address] = ENV['OUTGOING_ADDRESS']
 
   smtp_settings.delete_if { |k,v| v.blank? }
   default_options.delete_if { |k,v| v.blank? }

--- a/config/mail.yml.sample
+++ b/config/mail.yml.sample
@@ -20,3 +20,4 @@ cucumber:
 
 production:
   <<: *defaults
+  outgoing_address: "Canvas Rollcall <canvas@yourdomain.edu>"

--- a/config/mail.yml.sample
+++ b/config/mail.yml.sample
@@ -1,13 +1,16 @@
 ---
 defaults: &defaults
-  address: mail.yourdomain.edu
-  port: 465
-  authentication: plain
-  user_name: someuser
-  password: itsasecret
-  domain: yourdomain.edu
-  enable_starttls_auto: true
-  openssl_verify_mode: none
+  smtp:
+    address: mail.yourdomain.edu
+    port: 465
+    authentication: plain
+    user_name: someuser
+    password: itsasecret
+    domain: yourdomain.edu
+    enable_starttls_auto: true
+    openssl_verify_mode: none
+  default_options:
+    outgoing_address: "Canvas Rollcall <canvas@yourdomain.edu>"
 
 development:
   <<: *defaults
@@ -20,4 +23,3 @@ cucumber:
 
 production:
   <<: *defaults
-  outgoing_address: "Canvas Rollcall <canvas@yourdomain.edu>"

--- a/env.sample
+++ b/env.sample
@@ -35,4 +35,4 @@ SMTP_PASSWORD=itsasecret
 SMTP_DOMAIN=yourdomain.edu
 SMTP_ENABLE_STARTTLS_AUTO=true # true, false
 SMTP_OPENSSL_VERIFY_MODE=none # none, peer, client_once, fail_if_no_peer_cert
-SMTP_OUTGOING_ADDRESS=Canvas Rollcall <canvas@yourdomain.edu>
+OUTGOING_ADDRESS=Canvas Rollcall <canvas@yourdomain.edu>

--- a/env.sample
+++ b/env.sample
@@ -35,3 +35,4 @@ SMTP_PASSWORD=itsasecret
 SMTP_DOMAIN=yourdomain.edu
 SMTP_ENABLE_STARTTLS_AUTO=true # true, false
 SMTP_OPENSSL_VERIFY_MODE=none # none, peer, client_once, fail_if_no_peer_cert
+SMTP_OUTGOING_ADDRESS=Canvas Rollcall <canvas@yourdomain.edu>


### PR DESCRIPTION
The default from address ("Roll Call <notifications@instructure.com>") was hard-coded in place. This allows changing the outgoing address via either .env or mail.yml, while preserving notifications@instructure.com as the default, so not to break Instructure's production configuration.