### PR TITLE
Add environment variable for default course tardy weight

### DIFF
--- a/app/assets/javascripts/backbone/models/course_config.js.coffee.erb
+++ b/app/assets/javascripts/backbone/models/course_config.js.coffee.erb
@@ -24,7 +24,7 @@ class InstructureRollcall.Models.CourseConfig extends Backbone.Model
     tardy_weight: null
 
   tardyWeight: ->
-    @get('tardy_weight') || <%=ENV['COURSE_TARDY_WEIGHT']||0.8%>
+    @get('tardy_weight') || <%=ENV['COURSE_TARDY_WEIGHT']||0.80%>
 
   tardyWeightPercentage: ->
     Math.round (@tardyWeight() * 100)

--- a/app/assets/javascripts/backbone/models/course_config.js.coffee.erb
+++ b/app/assets/javascripts/backbone/models/course_config.js.coffee.erb
@@ -24,7 +24,7 @@ class InstructureRollcall.Models.CourseConfig extends Backbone.Model
     tardy_weight: null
 
   tardyWeight: ->
-    @get('tardy_weight') || 0.80
+    @get('tardy_weight') || <%=ENV['COURSE_TARDY_WEIGHT']||0.8%>
 
   tardyWeightPercentage: ->
     Math.round (@tardyWeight() * 100)

--- a/app/models/course_tardy_weight.rb
+++ b/app/models/course_tardy_weight.rb
@@ -25,6 +25,6 @@ class CourseTardyWeight
   end
 
   def self.default_tardy_weight
-    0.8
+    ENV['COURSE_TARDY_WEIGHT'] || 0.8
   end
 end

--- a/env.sample
+++ b/env.sample
@@ -40,3 +40,5 @@ SMTP_DOMAIN=yourdomain.edu
 SMTP_ENABLE_STARTTLS_AUTO=true # true, false
 SMTP_OPENSSL_VERIFY_MODE=none # none, peer, client_once, fail_if_no_peer_cert
 OUTGOING_ADDRESS=Canvas Rollcall <canvas@yourdomain.edu>
+
+COURSE_TARDY_WEIGHT=.8

--- a/env.sample
+++ b/env.sample
@@ -41,4 +41,4 @@ SMTP_ENABLE_STARTTLS_AUTO=true # true, false
 SMTP_OPENSSL_VERIFY_MODE=none # none, peer, client_once, fail_if_no_peer_cert
 OUTGOING_ADDRESS=Canvas Rollcall <canvas@yourdomain.edu>
 
-COURSE_TARDY_WEIGHT=.8
+COURSE_TARDY_WEIGHT=0.8


### PR DESCRIPTION
Some institutions created hundreds to even a few thousand courses each term, where they will have policies for tardies different than the default 0.8. This makes it possible to configure that default at the system level using an environment variable.