### PR TITLE
Update Redis Initializer to accept full URI

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,8 +42,6 @@ module InstructureRollcall
     # Enable escaping HTML in JSON.
     config.active_support.escape_html_entities_in_json = true
 
-    config.assets.paths << Rails.root.join("public")
-
     # Add kickstand to asset paths
     config.assets.paths << Rails.root.join("vendor", "assets", "kickstand")
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,6 +42,8 @@ module InstructureRollcall
     # Enable escaping HTML in JSON.
     config.active_support.escape_html_entities_in_json = true
 
+    config.assets.paths << Rails.root.join("public")
+
     # Add kickstand to asset paths
     config.assets.paths << Rails.root.join("vendor", "assets", "kickstand")
 

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -29,5 +29,4 @@ redis_uri = if ENV['REDIS_URL']
               default_uri
             end
 
-uri = URI.parse(redis_uri)
-$REDIS = Redis.new(host: uri.host, port: uri.port, password: uri.password)
+$REDIS = Redis.new(url: redis_uri)


### PR DESCRIPTION
`$REDIS = Redis.new(host: uri.host, port: uri.port, password: uri.password)` won't work if there is a username needed